### PR TITLE
fs/proc: hide magisk mounts for IsolatedService

### DIFF
--- a/fs/proc/Kconfig
+++ b/fs/proc/Kconfig
@@ -100,6 +100,13 @@ config PROC_CHILDREN
 	  Say Y if you are running any user-space software which takes benefit from
 	  this interface. For example, rkt is such a piece of software.
 
+config PROC_MAGISK_HIDE_MOUNT
+	bool "Prevent Magisk detection in /proc/pid/mounts"
+	default y
+	help
+	  Prevents detection of Magisk using traces left in the /proc/pid/mounts of
+	  an isolated process that activated Magisk Hide.
+
 config PROC_PID_ARCH_STATUS
 	def_bool n
 	depends on PROC_FS

--- a/fs/proc_namespace.c
+++ b/fs/proc_namespace.c
@@ -94,6 +94,20 @@ static void show_type(struct seq_file *m, struct super_block *sb)
 	}
 }
 
+static inline int skip_magisk_entry(const char *devname)
+{
+#ifdef CONFIG_PROC_MAGISK_HIDE_MOUNT
+	if (devname && strstr(devname, "magisk")) {
+		char name[TASK_COMM_LEN];
+		get_task_comm(name, current);
+		if (strstr(name, "Binder") || strstr(name, "JavaBridge")) {
+			return SEQ_SKIP;
+		}
+	}
+#endif /* CONFIG_PROC_MAGISK_HIDE_MOUNT */
+	return 0;
+}
+
 static int show_vfsmnt(struct seq_file *m, struct vfsmount *mnt)
 {
 	struct proc_mounts *p = m->private;
@@ -107,6 +121,9 @@ static int show_vfsmnt(struct seq_file *m, struct vfsmount *mnt)
 		if (err)
 			goto out;
 	} else {
+		err = skip_magisk_entry(r->mnt_devname);
+		if (err)
+			goto out;
 		mangle(m, r->mnt_devname ? r->mnt_devname : "none");
 	}
 	seq_putc(m, ' ');
@@ -179,6 +196,9 @@ static int show_mountinfo(struct seq_file *m, struct vfsmount *mnt)
 		if (err)
 			goto out;
 	} else {
+		err = skip_magisk_entry(r->mnt_devname);
+		if (err)
+			goto out;
 		mangle(m, r->mnt_devname ? r->mnt_devname : "none");
 	}
 	seq_puts(m, sb_rdonly(sb) ? " ro" : " rw");
@@ -210,6 +230,9 @@ static int show_vfsstat(struct seq_file *m, struct vfsmount *mnt)
 			goto out;
 	} else {
 		if (r->mnt_devname) {
+			err = skip_magisk_entry(r->mnt_devname);
+			if (err)
+				goto out;
 			seq_puts(m, "device ");
 			mangle(m, r->mnt_devname);
 		} else
@@ -252,6 +275,14 @@ static int mounts_open_common(struct inode *inode, struct file *file,
 
 	if (!task)
 		goto err;
+
+#ifdef CONFIG_PROC_MAGISK_HIDE_MOUNT
+	if(!strncmp("IsolatedService", task->comm, 15))
+	{
+		ret = -EINVAL;
+		goto err;
+	}
+#endif /* CONFIG_PROC_MAGISK_HIDE_MOUNT */
 
 	task_lock(task);
 	nsp = task->nsproxy;


### PR DESCRIPTION
Hey!

I absolutely love the kernel but it's missing one thing for me - Magisk Hide is being detected more and more (including the newer implementation via Zygisk) and this small code change helps to hide it further.

I've used it to great success on a few banking apps before and whilst it is possible in other ways - most of them are themselves detectable.

I'd appreciate if this could be merged but if it's not something you want to add I completely understand - I can always maintain a fork just for myself. :)

Thanks!